### PR TITLE
Include engine in the BottomSheet setup sample

### DIFF
--- a/docusaurus/docs/styles-and-animations.md
+++ b/docusaurus/docs/styles-and-animations.md
@@ -77,13 +77,15 @@ navController.navigatorProvider += bottomSheetNavigator
 
 ModalBottomSheetLayout(
     bottomSheetNavigator = bottomSheetNavigator,
-    //other configuration for you bottom sheet screens, like:
+    // other configuration for you bottom sheet screens, like:
     sheetShape = RoundedCornerShape(16.dp),
 ) {
-    //...
+    // ...
     DestinationsNavHost(
         navController = navController,
-        //...
+        // engine required for the BottomSheet
+        engine = rememberAnimatedNavHostEngine()
+        // ...
     )
 }
 ```


### PR DESCRIPTION
I copy pasted the BottomSheet Style from the docs to my project and tried to run it.
Seems like the `engine` parameter is required to be used.

To save a few clicks and "back and forth"s with the docs, I included the engine in the sample