### PR TITLE
Sample Code For One Function Per ViewModel

### DIFF
--- a/docusaurus/docs/common-use-cases/providing-viewmodels.md
+++ b/docusaurus/docs/common-use-cases/providing-viewmodels.md
@@ -253,7 +253,7 @@ fun profileViewModel(): ProfileViewModel {
     navArgsDelegate = ProfileScreenNavArgs::class
 )
 fun ProfileScreen(
-    vm: ProfileViewModel = profileViewModel()
+    viewModel: ProfileViewModel = profileViewModel()
 ){
     Text("Profile Screen")
 }


### PR DESCRIPTION
Currently under the section [Manual or no dependency injection](https://composedestinations.rafaelcosta.xyz/common-use-cases/providing-viewmodels#manual-or-no-dependency-injection), there is no code sample for when we want to provide one view model function per viewmodel for a composable screen.